### PR TITLE
Use console email backend for local development

### DIFF
--- a/pydotorg/settings/local.py
+++ b/pydotorg/settings/local.py
@@ -11,3 +11,5 @@ HAYSTACK_CONNECTIONS = {
         'INDEX_NAME': 'haystack',
     },
 }
+
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'


### PR DESCRIPTION
I think local development settings should be using console email backend to cut down dependencies on local services.
